### PR TITLE
8 express refactor for modular routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ This will build the Docker images (using development Dockerfiles when applicable
 Once the containers are running, you can access the services as follows:
 - MongoDB: Accessible internally or via GUI client like MongoDB Compass at localhost:27017
 - Express API:
-  - Test endpoint: http://localhost:3000/api/test-db
+  - Test endpoint: http://localhost:3000/api/test
   - The Express service uses nodemon for hot reloading in development. Changes to the code in the express/ directory are automatically detected and the express app will restart.
 - Flask API:
   - Test endpoint: http://localhost:5000/test-db
 - Vite-React Frontend (Development Mode)
   - Visit: http://localhost:5173
   - Hot reloading is enabled. Changes to the code in the vite-react/ directory will automatically update the UI in the browser.
+  - In development requests to /api are proxied to express on localhost:3000
 
 #### 4. Working with the Containers
 - Hot Reloading:

--- a/express/routes/api/index.js
+++ b/express/routes/api/index.js
@@ -1,10 +1,14 @@
 const express = require('express')
 const router = express.Router()
 
+const resumeRouter = require('./resume')
+
+router.use('/resume', resumeRouter)
+
 router.get('/test', (req, res) => {
   res.json({
     'msg': 'GET /api/test successful'
   })
-});
+})
 
 module.exports = router

--- a/express/routes/api/index.js
+++ b/express/routes/api/index.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+
+router.get('/test', (req, res) => {
+  res.json({
+    'msg': 'GET /api/test successful'
+  })
+});
+
+module.exports = router

--- a/express/routes/api/resume/index.js
+++ b/express/routes/api/resume/index.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+
+router.post('/', (req, res) => {
+  res.json({
+    'msg': 'POST /api/resume received'
+  })
+})
+
+module.exports = router

--- a/express/routes/index.js
+++ b/express/routes/index.js
@@ -1,0 +1,8 @@
+const express = require('express')
+const router = express.Router()
+
+const apiRouter = require('./api')
+
+router.use('/api', apiRouter)
+
+module.exports = router

--- a/express/server.js
+++ b/express/server.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const path = require('path')
 const mongoose = require('mongoose')
 require('dotenv').config()
 
@@ -6,9 +7,22 @@ require('dotenv').config()
 const PORT = process.env.PORT || 3000
 const app = express()
 
+// global middleware
+app.use(express.json())
+app.use(express.urlencoded({ extended: false }))
+
 // routes
 const router = require('./routes')
 app.use('/', router)
+
+// vite-react in production
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.static(path.join(__dirname, 'vite-react', 'dist')))
+
+  app.get('*', (req, res) => {
+    res.sendFile(path.resolve(__dirname, 'vite-react', 'dist', 'index.html'))
+  })
+}
 
 // db
 const mongooseConnection = require('./db/connection')

--- a/express/server.js
+++ b/express/server.js
@@ -2,33 +2,20 @@ const express = require('express')
 const mongoose = require('mongoose')
 require('dotenv').config()
 
+// express
 const PORT = process.env.PORT || 3000
-
-const mongooseConnection = require('./db/connection');
-
 const app = express()
 
-app.get('/api/test-db', async (req, res) => {
-  // Check if the native connection is ready
-  if (!mongoose.connection.db) {
-    return res.status(500).json({ error: 'MongoDB connection not ready' });
-  }
-  
-  try {
-    const collections = await mongoose.connection.db.listCollections().toArray();
-    res.json({
-      message: 'MongoDB connection successful!',
-      collections,
-    });
-  } catch (error) {
-    res.status(500).json({ error: 'Error accessing MongoDB', details: error.message });
-  }
-});
+// routes
+const router = require('./routes')
+app.use('/', router)
+
+// db
+const mongooseConnection = require('./db/connection')
 
 mongooseConnection.once('open', () => {
-  console.log(`Mongoose connection open`);
+  console.log(`Mongoose connection open`)
   app.listen(PORT, () => {
     console.log(`Express server listening on port ${PORT}`)
   })
-
 })

--- a/vite-react/vite.config.ts
+++ b/vite-react/vite.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
 })


### PR DESCRIPTION
- [x] modularizes express routes and file structure
- [x] adds vite-react proxy configuration so that requests made to /api are sent to localhost:3000 during development
- [x] updates readme regarding proxy
- [x] adds resume router and a test route: POST /api/resume