### PR TITLE
Add bullet regeneration endpoint with feedback integration

### DIFF
--- a/flask/services/mongodb_service.py
+++ b/flask/services/mongodb_service.py
@@ -302,12 +302,21 @@ Revise the bullet to better represent their self-concept while maintaining BSE t
 - Maintaining connection to job requirements
 - Preserving self-efficacy theory elements
 
-Variables available:
-- {bulletText} - Current bullet text
-- {rationale} - Current rationale
-- {rating} - User's 1-7 rating
-- {feedback} - User's open feedback
-- {iterationHistory} - Previous versions of this bullet
+Current bullet: "{bulletText}"
+Current rationale: "{rationale}"
+
+{iterationHistory}
+
+Return your response as JSON in this exact format:
+
+```json
+{{
+  "bullet": {{
+    "text": "Revised bullet point text that addresses user feedback",
+    "rationale": "Updated rationale explaining how this better represents the user while maintaining BSE theory focus"
+  }}
+}}
+```
 
 Generate an improved bullet that addresses the user's feedback while staying true to their authentic self-representation.""",
 


### PR DESCRIPTION
## Summary
- Implements bullet regeneration endpoint for collaborative alignment research
- Adds comprehensive validation for bullet_index, user_rating, and session data
- Supports iteration history to improve regeneration quality
- Integrates with prompt management system for configurable regeneration logic

## Changes Made
- **openai_service.py**: Added `regenerate_bullet()` and `parse_regenerated_bullet_response()` functions
- **mongodb_service.py**: Updated regeneration prompt to return structured JSON format
- **letter_lab.py**: Added POST `/lab/regenerate-bullet` endpoint with validation

## Validation
- Validates bullet_index must be 0, 1, or 2
- Validates user_rating must be between 1 and 7
- Validates session existence and current_bullet structure
- Parses JSON responses with proper error handling

## Test Plan
- [ ] Test endpoint with valid bullet regeneration requests
- [ ] Verify validation catches invalid bullet_index values
- [ ] Verify validation catches invalid user_rating values
- [ ] Test with missing session_id or invalid session
- [ ] Test with malformed current_bullet structure
- [ ] Verify JSON parsing handles LLM response correctly
- [ ] Test iteration history integration
- [ ] Verify progress logging works correctly

Closes #167